### PR TITLE
Adding AI impact tools to MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ The server provides several tools for interacting with the Jellyfish API. Each t
 
 - `get_api_schema` - Retrieves the complete API schema with all available API endpoints
 
+#### AI Impact
+
+- `ai_company_adoption_analytics`
+- `ai_company_impact_analytics`
+- `ai_person_adoption`
+- `ai_person_adoption_analytics`
+- `ai_team_adoption_analytics`
+- `ai_team_impact_analytics`
+
 #### Allocations
 
 - `allocations_by_person`

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "manifest_version": "0.3",
   "name": "jellyfish-mcp",
   "display_name": "Jellyfish MCP",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Connect to your Jellyfish Software Engineering Intelligence platform for comprehensive team insights, effort allocation, and delivery metrics.",
-  "long_description": "The Jellyfish MCP allows access to your engineering organization's data through 25 specialized tools. Query allocations by person, team, or investment category; track delivery metrics and scope changes; analyze sprint performance; search people and teams; and browse work categories and deliverables. Get instant insights into engineering productivity, resource allocation patterns, and project delivery timelines. Perfect for engineering managers, team leads, and executives who need data-driven insights about their organization's development processes. Supports Llama PromptGuard 2 which can detect responses from the Jellyfish API that might include prompt injection attacks. It is *highly* recommend to configure before using daily.\n\n**Jellyfish Setup (required):** Generate an API token from your Jellyfish instance (requires Admin User Role to access)\n1. Go to the [API Export](https://app.jellyfish.co/settings/data-connections/api-export) tab on the Data Connections page.\n2. Click Generate New Token.\n3. In the Generate New Token dialog, select a Time To Live value and click Generate. A new token is created and displayed in the dialog.\n4. Copy the token and paste it when prompted.\n\n**PromptGuard Setup (optional):** Generate an API token for prompt injection mitigation\n1. Create an account on [Hugging Face](https://huggingface.co).\n2. Navigate to the [PromptGuard 2 22M model](https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-22M).\n3. Access Meta's terms and request access to Llama models.\n4. Wait until you are granted access.\n5. Create a Hugging Face API token at [Hugging Face settings](https://huggingface.co/settings/tokens) that is a `fine-grained` token with `Make calls to Inference Providers` permissions.\n6. Copy the token and paste it when prompted.\n\n**Security Notice**: There are known risks and inherent limitations in this implementation. Refer to [`SECURITY.md`](https://github.com/Jellyfish-AI/jellyfish-mcp/blob/main/SECURITY.md) before using.",
+  "long_description": "The Jellyfish MCP allows access to your engineering organization's data through 31 specialized tools. Query allocations by person, team, or investment category; track delivery metrics and scope changes; analyze sprint performance; search people and teams; and browse work categories and deliverables. Get instant insights into engineering productivity, resource allocation patterns, and project delivery timelines. Perfect for engineering managers, team leads, and executives who need data-driven insights about their organization's development processes. Supports Llama PromptGuard 2 which can detect responses from the Jellyfish API that might include prompt injection attacks. It is *highly* recommend to configure before using daily.\n\n**Jellyfish Setup (required):** Generate an API token from your Jellyfish instance (requires Admin User Role to access)\n1. Go to the [API Export](https://app.jellyfish.co/settings/data-connections/api-export) tab on the Data Connections page.\n2. Click Generate New Token.\n3. In the Generate New Token dialog, select a Time To Live value and click Generate. A new token is created and displayed in the dialog.\n4. Copy the token and paste it when prompted.\n\n**PromptGuard Setup (optional):** Generate an API token for prompt injection mitigation\n1. Create an account on [Hugging Face](https://huggingface.co).\n2. Navigate to the [PromptGuard 2 22M model](https://huggingface.co/meta-llama/Llama-Prompt-Guard-2-22M).\n3. Access Meta's terms and request access to Llama models.\n4. Wait until you are granted access.\n5. Create a Hugging Face API token at [Hugging Face settings](https://huggingface.co/settings/tokens) that is a `fine-grained` token with `Make calls to Inference Providers` permissions.\n6. Copy the token and paste it when prompted.\n\n**Security Notice**: There are known risks and inherent limitations in this implementation. Refer to [`SECURITY.md`](https://github.com/Jellyfish-AI/jellyfish-mcp/blob/main/SECURITY.md) before using.",
   "author": {
     "name": "Jellyfish",
     "email": "ai@jellyfish.co",
@@ -39,6 +39,30 @@
     }
   },
   "tools": [
+    {
+      "name": "ai_company_adoption_analytics",
+      "description": "Returns per-tool AI adoption analytics aggregated across the entire company."
+    },
+    {
+      "name": "ai_company_impact_analytics",
+      "description": "Returns per-tool AI impact analytics aggregated across the entire company."
+    },
+    {
+      "name": "ai_person_adoption",
+      "description": "Returns per-tool AI adoption usage dates for the specified people."
+    },
+    {
+      "name": "ai_person_adoption_analytics",
+      "description": "Returns per-tool AI adoption analytics for the specified people."
+    },
+    {
+      "name": "ai_team_impact_analytics",
+      "description": "Returns per-tool AI impact analytics for the specified teams."
+    },
+    {
+      "name": "ai_team_adoption_analytics",
+      "description": "Returns per-tool AI adoption analytics aggregated by team."
+    },
     {
       "name": "allocations_by_person",
       "description": "Returns allocation data for the whole company, aggregated by person."
@@ -187,7 +211,8 @@
     "api",
     "data",
     "insights",
-    "management"
+    "management",
+    "ai"
   ],
   "license": "MIT"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jellyfish-mcp-server",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jellyfish-mcp-server",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",
         "@toon-format/toon": "^2.0.0",
@@ -14,9 +14,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.12",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
-      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "engines": {
         "node": ">=18.14.1"
       },
@@ -175,9 +175,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "engines": {
         "node": ">=18"
       },
@@ -540,9 +540,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.10",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
-      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -788,9 +788,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -937,12 +937,12 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jellyfish-mcp-server",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "main": "server/index.js",
   "scripts": {

--- a/server/api.js
+++ b/server/api.js
@@ -136,6 +136,37 @@ async function api_generic(endpoint, params = {}) {
     }
 }
 
+// --- AI IMPACT ---
+export async function api_ai_company_adoption_analytics(params = {}) {
+    const endpoint = "/endpoints/export/v0/ai_impact/company_adoption_analytics";
+    return await api_generic(endpoint, params);
+}
+
+export async function api_ai_company_impact_analytics(params = {}) {
+    const endpoint = "/endpoints/export/v0/ai_impact/company_impact_analytics";
+    return await api_generic(endpoint, params);
+}
+
+export async function api_ai_person_adoption(params = {}) {
+    const endpoint = "/endpoints/export/v0/ai_impact/person_adoption";
+    return await api_generic(endpoint, params);
+}
+
+export async function api_ai_person_adoption_analytics(params = {}) {
+    const endpoint = "/endpoints/export/v0/ai_impact/person_adoption_analytics";
+    return await api_generic(endpoint, params);
+}
+
+export async function api_ai_team_impact_analytics(params = {}) {
+    const endpoint = "/endpoints/export/v0/ai_impact/team_impact_analytics";
+    return await api_generic(endpoint, params);
+}
+
+export async function api_ai_team_adoption_analytics(params = {}) {
+    const endpoint = "/endpoints/export/v0/ai_impact/team_adoption_analytics";
+    return await api_generic(endpoint, params);
+}
+
 // --- ALLOCATIONS ---
 export async function api_allocations_by_person(params = {}) {
     const endpoint = "/endpoints/export/v0/allocations/details/by_person";

--- a/server/index.js
+++ b/server/index.js
@@ -154,6 +154,95 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
 server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {
         tools: [
+            // AI IMPACT
+            {
+                name: "ai_company_adoption_analytics",
+                description: "Returns per-tool AI adoption analytics aggregated across the entire company, including cohort counts and average usage percentage.",
+                inputSchema: {
+                    type: "object",
+                    properties: {
+                        format: { type: "string", default: "json", description: "Response format" },
+                        start_date: { type: "string", description: "Start date (YYYY-MM-DD)" },
+                        end_date: { type: "string", description: "End date (YYYY-MM-DD)" },
+                        unit: { type: "string", description: "Time unit (\"quarter\", \"month\", \"week\")" }
+                    },
+                    required: []
+                }
+            },
+            {
+                name: "ai_company_impact_analytics",
+                description: "Returns per-tool AI impact analytics aggregated across the entire company, including median issue cycle time, median PR cycle time, total PR throughput, and total AI adoption lines.",
+                inputSchema: {
+                    type: "object",
+                    properties: {
+                        format: { type: "string", default: "json", description: "Response format" },
+                        start_date: { type: "string", description: "Start date (YYYY-MM-DD)" },
+                        end_date: { type: "string", description: "End date (YYYY-MM-DD)" },
+                        unit: { type: "string", description: "Time unit (\"quarter\", \"month\", \"week\")" }
+                    },
+                    required: []
+                }
+            },
+            {
+                name: "ai_person_adoption",
+                description: "Returns per-tool AI adoption usage dates for the specified people, with a breakdown by each configured tool.",
+                inputSchema: {
+                    type: "object",
+                    properties: {
+                        format: { type: "string", default: "json", description: "Response format" },
+                        start_date: { type: "string", description: "Start date (YYYY-MM-DD)" },
+                        end_date: { type: "string", description: "End date (YYYY-MM-DD)" },
+                        unit: { type: "string", description: "Time unit (\"quarter\", \"month\", \"week\")" },
+                        person_id: { type: "array", items: {type: "integer"}, description: "List of person IDs" }
+                    },
+                    required: ["person_id"]
+                }
+            },
+            {
+                name: "ai_person_adoption_analytics",
+                description: "Returns per-tool AI adoption analytics for the specified people, including cohort and usage percentage.",
+                inputSchema: {
+                    type: "object",
+                    properties: {
+                        format: { type: "string", default: "json", description: "Response format" },
+                        start_date: { type: "string", description: "Start date (YYYY-MM-DD)" },
+                        end_date: { type: "string", description: "End date (YYYY-MM-DD)" },
+                        unit: { type: "string", description: "Time unit (\"quarter\", \"month\", \"week\")" },
+                        person_id: { type: "array", items: {type: "integer"}, description: "List of person IDs" }
+                    },
+                    required: ["person_id"]
+                }
+            },
+            {
+                name: "ai_team_impact_analytics",
+                description: "Returns per-tool AI impact analytics for the specified teams, including median issue cycle time, median PR cycle time, and total PR throughput.",
+                inputSchema: {
+                    type: "object",
+                    properties: {
+                        format: { type: "string", default: "json", description: "Response format" },
+                        start_date: { type: "string", description: "Start date (YYYY-MM-DD)" },
+                        end_date: { type: "string", description: "End date (YYYY-MM-DD)" },
+                        unit: { type: "string", description: "Time unit (\"quarter\", \"month\", \"week\")" },
+                        team_id: { type: "array", items: { type: "integer" }, description: "List of Jellyfish team IDs" }
+                    },
+                    required: ["team_id"]
+                }
+            },
+            {
+                name: "ai_team_adoption_analytics",
+                description: "Returns per-tool AI adoption analytics aggregated by team, including cohort counts and average usage percentage.",
+                inputSchema: {
+                    type: "object",
+                    properties: {
+                        format: { type: "string", default: "json", description: "Response format" },
+                        start_date: { type: "string", description: "Start date (YYYY-MM-DD)" },
+                        end_date: { type: "string", description: "End date (YYYY-MM-DD)" },
+                        unit: { type: "string", description: "Time unit (\"quarter\", \"month\", \"week\")" },
+                        team_id: { type: "array", items: { type: "integer" }, description: "List of team IDs" }
+                    },
+                    required: ["team_id"]
+                }
+            },
             // ALLOCATIONS
             {
                 name: "allocations_by_person",
@@ -577,11 +666,25 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     };
 });
 
-// Handler to execute tool calls (processes requests for all 24 Jellyfish API tools)
+// Handler to execute tool calls
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const params = filter_params(request.params.arguments || {});
 
     switch (request.params.name) {
+        // AI IMPACT
+        case "ai_company_adoption_analytics":
+            return process_tool_response(await api.api_ai_company_adoption_analytics(params));
+        case "ai_company_impact_analytics":
+            return process_tool_response(await api.api_ai_company_impact_analytics(params));
+        case "ai_person_adoption":
+            return process_tool_response(await api.api_ai_person_adoption(params));
+        case "ai_person_adoption_analytics":
+            return process_tool_response(await api.api_ai_person_adoption_analytics(params));
+        case "ai_team_impact_analytics":
+            return process_tool_response(await api.api_ai_team_impact_analytics(params));
+        case "ai_team_adoption_analytics":
+            return process_tool_response(await api.api_ai_team_adoption_analytics(params));
+
         // ALLOCATIONS
         case "allocations_by_person":
             return process_tool_response(await api.api_allocations_by_person(params));


### PR DESCRIPTION
Adding 6 additional tools to query AI adoption and impact metrics. Users can now ask questions about person, team, and company-level AI tool adoption -- including per-tool usage breakdowns, cohort counts, and usage percentages -- as well as AI impact analytics like median issue cycle time, median PR cycle time, PR throughput, and AI adoption lines.
- `ai_company_adoption_analytics`
- `ai_company_impact_analytics`
- `ai_person_adoption`
- `ai_person_adoption_analytics`
- `ai_team_adoption_analytics`
- `ai_team_impact_analytics`