### PR TITLE
SCI-34: Add npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish Package
+on:
+  push:
+    tags:
+      - 'v*'
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+      - run: npm publish


### PR DESCRIPTION
 Adds `.github/workflows/publish.yml`, which publishes this package to npm via [trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers)