### PR TITLE
[SECTEAM-2421] Add support for detect-secrets as pre-commit hook

### DIFF
--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install detect-secrets
-        run: pip install -r <(echo "detect-secrets==1.5.0 --hash=sha256:6bb46dcc553c10df51475641bb30fd69d25645cc12339e46c824c1e0c388898a"  # pragma: allowlist secret
+        run: pip install -r <(echo "detect-secrets==1.5.0 --hash=sha256:6bb46dcc553c10df51475641bb30fd69d25645cc12339e46c824c1e0c388898a)"  # pragma: allowlist secret
       - name: Run detect secrets.
         run: git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} |  xargs detect-secrets-hook
 

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install detect-secrets
-        run: pip install detect-secrets
+        run: pip install -r <(echo "detect-secrets==1.5.0 --hash=sha256:6bb46dcc553c10df51475641bb30fd69d25645cc12339e46c824c1e0c388898a"  # pragma: allowlist secret
       - name: Run detect secrets.
         run: git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} |  xargs detect-secrets-hook
 

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install detect-secrets
-        run: pip install -r <(echo "detect-secrets==1.5.0 --hash=sha256:6bb46dcc553c10df51475641bb30fd69d25645cc12339e46c824c1e0c388898a)"  # pragma: allowlist secret
+        run: pip install -r <(echo "detect-secrets==1.5.0 --hash=sha256:6bb46dcc553c10df51475641bb30fd69d25645cc12339e46c824c1e0c388898a")  # pragma: allowlist secret
       - name: Run detect secrets.
         run: git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} |  xargs detect-secrets-hook
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/Yelp/detect-secrets
+    # v.1.5.0
+    rev: 01886c8a910c64595c47f186ca1ffc0b77fa5458  # pragma: allowlist secret
+    hooks:
+      - id: detect-secrets
+        # If you need to change this, be sure to update .circleci/config.yml as well
+        exclude: package-lock.json|Pipfile.lock|.bandit-baseline.json|.secrets.yaml|app_api_schema.yaml
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,4 @@ repos:
     rev: 01886c8a910c64595c47f186ca1ffc0b77fa5458  # pragma: allowlist secret
     hooks:
       - id: detect-secrets
-        # If you need to change this, be sure to update .circleci/config.yml as well
-        exclude: package-lock.json|Pipfile.lock|.bandit-baseline.json|.secrets.yaml|app_api_schema.yaml
 


### PR DESCRIPTION
This PR adds a pre-commit hook that can be used to detect possible secrets *before* they are committed to a repo. It mirrors our CI logic, but makes it available earlier.