### PR TITLE
Pinning the @latest tag for npx installation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -61,7 +61,7 @@ claude mcp add jellyfish-mcp \
   -e HUGGINGFACE_API_TOKEN=your_huggingface_token \
   -e MODEL_AVAILABILITY=false \
   -e MODEL_TIMEOUT=10 \
-  -- npx -y jellyfish-mcp-server
+  -- npx -y jellyfish-mcp-server@latest
 ```
 
 Run `claude mcp list` to verify.
@@ -96,7 +96,7 @@ Run `claude mcp list` to verify.
   "mcpServers": {
     "jellyfish-mcp": {
       "command": "npx",
-      "args": ["-y", "jellyfish-mcp-server"],
+      "args": ["-y", "jellyfish-mcp-server@latest"],
       "env": {
         "JELLYFISH_API_TOKEN": "your_jellyfish_token",
         "HUGGINGFACE_API_TOKEN": "your_huggingface_token",
@@ -148,7 +148,7 @@ Run `claude mcp list` to verify.
     "jellyfish-mcp": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "jellyfish-mcp-server"],
+      "args": ["-y", "jellyfish-mcp-server@latest"],
       "env": {
         "JELLYFISH_API_TOKEN": "your_jellyfish_token",
         "HUGGINGFACE_API_TOKEN": "your_huggingface_token",
@@ -194,5 +194,6 @@ Run `claude mcp list` to verify.
 - Verify your `JELLYFISH_API_TOKEN` is correct and has the necessary permissions.
 - Ensure your Jellyfish instance is reachable from your machine.
 - For npx, confirm Node.js v18 or later is installed: `node --version`.
+- For npx, make sure you're on the latest release by using the `@latest` tag: `npx -y jellyfish-mcp-server@latest`.
 - For Docker, confirm Docker is running: `docker info`.
 - If PromptGuard is unexpectedly blocking responses, set `MODEL_AVAILABILITY=true` to allow data through when PromptGuard can't be reached, or unset `HUGGINGFACE_API_TOKEN` to disable PromptGuard entirely.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Model Context Protocol server for retrieving and analyzing data from Jellyfish
 
 Once you have the Jellyfish MCP connected, you can ask questions about your Jellyfish data, such as:
 
-- "What were our company metrics in December 2025?"
+- "What were our company metrics in May 2026?"
 - "Can you get a list of my organization's teams?"
 - "What are the unlinked pull requests for the last month?"
 
@@ -25,7 +25,7 @@ Once you have the Jellyfish MCP connected, you can ask questions about your Jell
 See **[INSTALL.md](INSTALL.md)** for the full setup guide. Quick links:
 
 - **Claude Desktop** — [download the `.mcpb` extension](https://github.com/Jellyfish-AI/jellyfish-mcp/releases/latest/download/jellyfish-mcp.mcpb), then double-click to install
-- **Claude Code, Cursor, VSCode** — `npx jellyfish-mcp-server` (recommended) or Docker
+- **Claude Code, Cursor, VSCode** — `npx jellyfish-mcp-server@latest` (recommended) or Docker
 
 ## Develop
 


### PR DESCRIPTION
Pinning the `@latest` tag for npx installation so users pull the most up-to-date published version. Without it, npx may reuse a cached, out-of-date version.

Files changed:
- `README.md` - npx snippet
- `INSTALL.md` - npx snippets (Claude Code, Cursor, VSCode) and a troubleshooting note