### PR TITLE
Add X-Jellyfish-MCP-Meta observability header

### DIFF
--- a/server/api.js
+++ b/server/api.js
@@ -3,6 +3,7 @@ import yaml from 'js-yaml';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { buildOutboundHeaders } from './meta.js';
 
 // Get version from package.json
 const __filename = fileURLToPath(import.meta.url);
@@ -30,7 +31,7 @@ const HEADERS = {
 // Function to fetch and process the schema
 async function fetch_schema() {
     try {
-        const response = await fetch(SCHEMA_URL, { headers: HEADERS });
+        const response = await fetch(SCHEMA_URL, { headers: buildOutboundHeaders(HEADERS) });
 
         if (response.ok) {
             const responseText = await response.text();
@@ -104,7 +105,7 @@ async function api_generic(endpoint, params = {}) {
     });
 
     try {
-        const response = await fetch(url, { headers: HEADERS });
+        const response = await fetch(url, { headers: buildOutboundHeaders(HEADERS) });
 
         if (response.ok) {
             const data = await response.json();

--- a/server/index.js
+++ b/server/index.js
@@ -14,6 +14,7 @@ import {
 import * as api from "./api.js";
 import { encode } from '@toon-format/toon';
 import { sanitize_api_response } from './sanitizer.js';
+import { setTransport, setTools, attachInitializeCapture } from './mcp_context.js';
 
 // Get version from package.json
 const __filename = fileURLToPath(import.meta.url);
@@ -34,6 +35,9 @@ const server = new Server(
         }
     }
 );
+
+setTransport('stdio');
+attachInitializeCapture(server);
 
 // Helper function to filter out undefined/null/empty array values from parameters
 function filter_params(params) {
@@ -694,6 +698,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 
 // Handler to execute tool calls
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    setTools(request.params.name);
     const params = filter_params(request.params.arguments || {});
 
     switch (request.params.name) {

--- a/server/mcp_context.js
+++ b/server/mcp_context.js
@@ -1,0 +1,80 @@
+import os from 'node:os';
+import { existsSync } from 'node:fs';
+import { getProcessId, getProcessStartTs } from './process.js';
+
+// Resolved once at startup; install method can't change within a process.
+const _install = existsSync('/.dockerenv')
+  ? 'docker'
+  : process.env.npm_config_user_agent
+    ? 'npm'
+    : 'local';
+
+let _clientName = null;
+let _clientVersion = null;
+let _protocolVersion = null;
+let _transport = null;
+let _tools = null;
+
+function setClientInfo(info) {
+  if (info && typeof info === 'object') {
+    _clientName = info.name ?? null;
+    _clientVersion = info.version ?? null;
+  } else {
+    _clientName = null;
+    _clientVersion = null;
+  }
+}
+
+export function setProtocolVersion(v) {
+  _protocolVersion = v ?? null;
+}
+
+// No public getter exposes these post-handshake, so we wrap the SDK's
+// private `_oninitialize`. No-op if the SDK changes.
+export function attachInitializeCapture(server) {
+  const orig = typeof server._oninitialize === 'function'
+    ? server._oninitialize.bind(server)
+    : null;
+  if (!orig) return;
+  server._oninitialize = async (request) => {
+    const params = (request && request.params) || {};
+    if (params.protocolVersion) setProtocolVersion(params.protocolVersion);
+    if (params.clientInfo) setClientInfo(params.clientInfo);
+    return orig(request);
+  };
+}
+
+export function setTransport(t) {
+  _transport = t ?? null;
+}
+
+// The tool invoked on the current call, set per CallTool request.
+export function setTools(t) {
+  _tools = t ?? null;
+}
+
+export function getProcessContext() {
+  return {
+    'mcp.client.name': _clientName,
+    'mcp.client.version': _clientVersion,
+    'mcp.protocol.version': _protocolVersion,
+    'mcp.transport': _transport,
+    'mcp.tools': _tools,
+    'mcp.process.id': getProcessId(),
+    'mcp.process.start_ts': getProcessStartTs(),
+    'mcp.os': `${os.platform()}-${os.arch()}`,
+    'mcp.node': process.version,
+    'mcp.install': _install,
+    'mcp.promptguard.enabled': Boolean(process.env.HUGGINGFACE_API_TOKEN),
+    'mcp.promptguard.timeout': Number(process.env.MODEL_TIMEOUT) || 10,
+    'mcp.promptguard.allow_on_unavailable': process.env.MODEL_AVAILABILITY === 'true',
+  };
+}
+
+export function resetMcpContextForTests() {
+  _clientName = null;
+  _clientVersion = null;
+  _protocolVersion = null;
+  _transport = null;
+  _tools = null;
+}

--- a/server/meta.js
+++ b/server/meta.js
@@ -1,0 +1,26 @@
+// `mcp.seq` increments per request, so outbound calls from one process can be
+// ordered relative to each other.
+
+import { getProcessContext, resetMcpContextForTests } from './mcp_context.js';
+import { nextSeq, peekSeq, resetProcessForTests } from './process.js';
+
+export const HEADER_NAME = 'X-Jellyfish-MCP-Meta';
+
+export function getMetaPayload({ consumeSeq = true } = {}) {
+  return {
+    ...getProcessContext(),
+    'mcp.seq': consumeSeq ? nextSeq() : peekSeq(),
+  };
+}
+
+export function buildOutboundHeaders(baseHeaders) {
+  return {
+    ...baseHeaders,
+    [HEADER_NAME]: JSON.stringify(getMetaPayload()),
+  };
+}
+
+export function resetMetaForTests() {
+  resetProcessForTests();
+  resetMcpContextForTests();
+}

--- a/server/process.js
+++ b/server/process.js
@@ -1,0 +1,30 @@
+// `process_id` is per-MCP-process, not per-conversation: a client may reuse one
+// process across many conversations, so treat this as process-lifetime identity.
+
+import { randomUUID } from 'node:crypto';
+
+let process_id = randomUUID();
+let process_start_ts = Date.now();
+let seq = 0;
+
+export function getProcessId() {
+  return process_id;
+}
+
+export function getProcessStartTs() {
+  return process_start_ts;
+}
+
+export function nextSeq() {
+  return ++seq;
+}
+
+export function peekSeq() {
+  return seq;
+}
+
+export function resetProcessForTests() {
+  process_id = randomUUID();
+  process_start_ts = Date.now();
+  seq = 0;
+}


### PR DESCRIPTION
## What

Adds an `X-Jellyfish-MCP-Meta` header to outbound Jellyfish API requests, carrying process-level MCP context so server-side telemetry can attribute API traffic to MCP usage (client, protocol, transport, install method, PromptGuard config, and the tool invoked on each call).

The header is a JSON object with 14 `mcp.*` fields:

| field | source |
| --- | --- |
| `mcp.client.name`, `mcp.client.version` | `clientInfo` from the `initialize` handshake |
| `mcp.protocol.version` | `protocolVersion` from `initialize` |
| `mcp.transport` | `"stdio"` |
| `mcp.tools` | the single tool name invoked on this CallTool request |
| `mcp.process.id`, `mcp.process.start_ts` | per-process UUID + start time |
| `mcp.seq` | monotonic per-process request counter |
| `mcp.os`, `mcp.node` | `os.platform()-arch`, Node version |
| `mcp.install` | `docker` / `npm` / `local` |
| `mcp.promptguard.enabled` / `.timeout` / `.allow_on_unavailable` | PromptGuard env config |

## Changes

- **`server/process.js`** (new) — per-process id, start ts, monotonic seq
- **`server/mcp_context.js`** (new) — process-level dimensions + `initialize`-handshake capture (`clientInfo` + `protocolVersion`)
- **`server/meta.js`** (new) — header name + payload assembly (`buildOutboundHeaders`)
- **`server/api.js`** — wraps the two outbound `fetch` headers with `buildOutboundHeaders(HEADERS)`
- **`server/index.js`** — `setTransport('stdio')`, `attachInitializeCapture(server)`, and `setTools(request.params.name)` at the top of the CallTool handler

New files are self-contained (Node built-ins + each other only). No new dependencies.

## Privacy / data

No PII or customer data — fields are process/environment metadata and the public tool name (a release constant). Server-side ingestion is gated on the account's analytics setting; the header itself is sent regardless.

## Verification

Smoke-tested against this branch over stdio: `initialize` handshake captures `clientInfo` + `protocolVersion`; a tool call emits `X-Jellyfish-MCP-Meta` on the outbound request with all 14 fields and `mcp.tools` = the invoked tool.

Docs (README / opt-out) deferred — happy to add if reviewers want them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)