### PR TITLE
SCI-45: Automate version bumps

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -10,6 +10,9 @@ jobs:
     # Only run when the PR was actually merged, not just closed
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    concurrency:
+      group: bump-version
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -28,7 +31,7 @@ jobs:
           elif ${{ contains(github.event.pull_request.labels.*.name, 'patch') }}; then
             echo "type=patch" >> $GITHUB_OUTPUT
           else
-            # No bump label — skip remaining steps gracefully
+            # This shouldn't happen in practice since check-bump-label.yml is a required status check
             echo "type=none" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,48 @@
+name: Bump Version on Merge
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  bump:
+    # Only run when the PR was actually merged, not just closed
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Determine bump type
+        id: bump-type
+        run: |
+          if ${{ contains(github.event.pull_request.labels.*.name, 'major') }}; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif ${{ contains(github.event.pull_request.labels.*.name, 'minor') }}; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          elif ${{ contains(github.event.pull_request.labels.*.name, 'patch') }}; then
+            echo "type=patch" >> $GITHUB_OUTPUT
+          else
+            # No bump label — skip remaining steps gracefully
+            echo "type=none" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: actions/setup-node@v6
+        if: steps.bump-type.outputs.type != 'none'
+        with:
+          node-version: '24'
+
+      - name: Bump version
+        if: steps.bump-type.outputs.type != 'none'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # npm version bumps package.json, commits, and creates a git tag automatically
+          npm version ${{ steps.bump-type.outputs.type }} -m "bump version to %s [skip ci]"
+          # --follow-tags pushes both the commit and the new version tag
+          git push --follow-tags

--- a/.github/workflows/check-bump-label.yml
+++ b/.github/workflows/check-bump-label.yml
@@ -1,0 +1,25 @@
+name: Require Bump Label
+on:
+  # Re-runs whenever labels change or new commits are pushed, so the check stays current
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, reopened]
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for bump label
+        run: |
+          has_patch=${{ contains(github.event.pull_request.labels.*.name, 'patch') }}
+          has_minor=${{ contains(github.event.pull_request.labels.*.name, 'minor') }}
+          has_major=${{ contains(github.event.pull_request.labels.*.name, 'major') }}
+          count=$(( ($has_patch == 'true') + ($has_minor == 'true') + ($has_major == 'true') ))
+          if [ "$count" -eq 0 ]; then
+            echo "Error: PR must have exactly one of these labels: patch, minor, major"
+            exit 1
+          elif [ "$count" -gt 1 ]; then
+            # Prevent ambiguity — only one bump type allowed per PR
+            echo "Error: PR has multiple bump labels — use exactly one of: patch, minor, major"
+            exit 1
+          fi
+          echo "Bump label found"

--- a/.github/workflows/check-bump-label.yml
+++ b/.github/workflows/check-bump-label.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - name: Check for bump label
         run: |
-          has_patch=${{ contains(github.event.pull_request.labels.*.name, 'patch') }}
-          has_minor=${{ contains(github.event.pull_request.labels.*.name, 'minor') }}
-          has_major=${{ contains(github.event.pull_request.labels.*.name, 'major') }}
-          count=$(( ($has_patch == 'true') + ($has_minor == 'true') + ($has_major == 'true') ))
+          count=0
+          ${{ contains(github.event.pull_request.labels.*.name, 'patch') }} && count=$((count + 1)) || true
+          ${{ contains(github.event.pull_request.labels.*.name, 'minor') }} && count=$((count + 1)) || true
+          ${{ contains(github.event.pull_request.labels.*.name, 'major') }} && count=$((count + 1)) || true
           if [ "$count" -eq 0 ]; then
             echo "Error: PR must have exactly one of these labels: patch, minor, major"
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,23 @@
 name: Publish Package
 on:
-  push:
-    tags:
-      - 'v*'
+  # Triggered by the Bump Version workflow completing — avoids needing a PAT for cross-workflow triggers
+  workflow_run:
+    workflows: ["Bump Version on Merge"]
+    types: [completed]
 permissions:
   id-token: write
   contents: read
 jobs:
   publish:
+    # Only publish if the version bump succeeded
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Explicitly checkout main so we get the bumped version commit
+          ref: main
       - uses: actions/setup-node@v6
         with:
           node-version: '24'


### PR DESCRIPTION
 ## Summary
  - Adds `check-bump-label.yml` — required status check that enforces exactly one of `patch`, `minor`, or `major` labels on every PR before
  merge
  - Adds `bump-version.yml` — on merge to main, reads the label and runs `npm version` to commit the bump and push a git tag
  - Updates `publish.yml` to trigger via `workflow_run` on `bump-version.yml` completion instead of tag push, avoiding the need for a PAT
  