### PR TITLE
docs: clarify Cursor npx setup with PATH context and full path guidance

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,17 +85,24 @@ claude mcp add jellyfish-mcp \
 Run `claude mcp list` to verify.
 
 ### Cursor
+> Cursor runs its own isolated bash environment so it does not have access to the location of npx
+> because it does not inherit your terminal's environment variables (like PATH)
 
+**Before configuration**
+* Ensure that `npx` is installed. (`npx -v`) **npx** — requires Node.js v18 or later. 
+* Find the path to your npx installation (Bash example: `which npx`)
+
+**Configuration** 
 1. Open _Cursor Settings_ (_Cursor_ → _Settings..._ → _Cursor Settings_ on macOS).
 2. Go to _Tools & MCP_ → _Add Custom MCP_.
 
-**npx** — requires Node.js v18 or later. Add to `mcp.json`:
+Add to `mcp.json`:
 
 ```json
 {
   "mcpServers": {
     "jellyfish-mcp": {
-      "command": "npx",
+      "command": "path/to/npx",
       "args": ["-y", "jellyfish-mcp-server@latest"],
       "env": {
         "JELLYFISH_API_TOKEN": "your_jellyfish_token",

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,25 +85,40 @@ claude mcp add jellyfish-mcp \
 Run `claude mcp list` to verify.
 
 ### Cursor
-> Cursor runs its own isolated bash environment so it does not have access to the location of npx
-> because it does not inherit your terminal's environment variables (like PATH)
 
-**Before configuration**
-* Ensure that `npx` is installed. (`npx -v`) **npx** — requires Node.js v18 or later. 
-* Find the path to your npx installation (Bash example: `which npx`)
+**npx** — requires Node.js v18 or later.
 
-**Configuration** 
-1. Open _Cursor Settings_ (_Cursor_ → _Settings..._ → _Cursor Settings_ on macOS).
-2. Go to _Tools & MCP_ → _Add Custom MCP_.
+> Cursor runs its own isolated bash environment so it does not have access to the location of npx because it does not inherit your terminal's environment variables (like PATH). Depending on how Node is installed, `"command": "npx"` may fail to connect (see step 4).
 
-Add to `mcp.json`:
+1. Open _Cursor Settings_ (_Cursor_ → _Preferences_ → _Cursor Settings_ on macOS).
+2. Go to _Tools & MCPs_ → _Add Custom MCP_.
+3. Add to `mcp.json`:
 
 ```json
 {
   "mcpServers": {
     "jellyfish-mcp": {
-      "command": "path/to/npx",
+      "command": "npx",
       "args": ["-y", "jellyfish-mcp-server@latest"],
+      "env": {
+        "JELLYFISH_API_TOKEN": "your_jellyfish_token",
+        "HUGGINGFACE_API_TOKEN": "your_huggingface_token",
+        "MODEL_AVAILABILITY": "false",
+        "MODEL_TIMEOUT": "10"
+      }
+    }
+  }
+}
+```
+
+4. If it fails to connect (common with a Node version manager), point `command` directly at your `node` binary and pass `npx` as the first arg. Find both with `which node` and `which npx`. Note: these paths may include your Node version, so this can break when you upgrade Node. If you'd rather not manage paths, use Docker below.
+
+```json
+{
+  "mcpServers": {
+    "jellyfish-mcp": {
+      "command": "path/to/node",
+      "args": ["path/to/npx", "-y", "jellyfish-mcp-server@latest"],
       "env": {
         "JELLYFISH_API_TOKEN": "your_jellyfish_token",
         "HUGGINGFACE_API_TOKEN": "your_huggingface_token",
@@ -202,5 +217,6 @@ Add to `mcp.json`:
 - Ensure your Jellyfish instance is reachable from your machine.
 - For npx, confirm Node.js v18 or later is installed: `node --version`.
 - For npx, make sure you're on the latest release by using the `@latest` tag: `npx -y jellyfish-mcp-server@latest`.
+- In Cursor, if the server fails to connect with an error like `ENOENT ... /Applications/Cursor.app/.../resources/lib`, Cursor is falling back to its own bundled Node instead of yours (it doesn't inherit your terminal's `PATH`). This is common with a Node version manager (mise/nvm/asdf). Fix it by pointing `command` directly at your `node` binary and passing `npx` as the first arg — see step 4 of the [Cursor](#cursor) setup.
 - For Docker, confirm Docker is running: `docker info`.
 - If PromptGuard is unexpectedly blocking responses, set `MODEL_AVAILABILITY=true` to allow data through when PromptGuard can't be reached, or unset `HUGGINGFACE_API_TOKEN` to disable PromptGuard entirely.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -86,13 +86,13 @@ Run `claude mcp list` to verify.
 
 ### Cursor
 
-**npx** — requires Node.js v18 or later.
-
-> Cursor runs its own isolated bash environment so it does not have access to the location of npx because it does not inherit your terminal's environment variables (like PATH). Depending on how Node is installed, `"command": "npx"` may fail to connect (see step 4).
-
 1. Open _Cursor Settings_ (_Cursor_ → _Preferences_ → _Cursor Settings_ on macOS).
 2. Go to _Tools & MCPs_ → _Add Custom MCP_.
 3. Add to `mcp.json`:
+
+**npx** — requires Node.js v18 or later.
+
+> Cursor runs its own isolated bash environment so it does not have access to the location of npx because it does not inherit your terminal's environment variables (like PATH). Depending on how Node is installed, `"command": "npx"` may fail to connect.
 
 ```json
 {
@@ -111,7 +111,7 @@ Run `claude mcp list` to verify.
 }
 ```
 
-4. If it fails to connect (common with a Node version manager), point `command` directly at your `node` binary and pass `npx` as the first arg. Find both with `which node` and `which npx`. Note: these paths may include your Node version, so this can break when you upgrade Node. If you'd rather not manage paths, use Docker below.
+If it fails to connect (common with a Node version manager), point `command` directly at your `node` binary and pass `npx` as the first arg. Find both with `which node` and `which npx`. Note: these paths may include your Node version, so this can break when you upgrade Node. If you'd rather not manage paths, use Docker below.
 
 ```json
 {
@@ -217,6 +217,6 @@ Run `claude mcp list` to verify.
 - Ensure your Jellyfish instance is reachable from your machine.
 - For npx, confirm Node.js v18 or later is installed: `node --version`.
 - For npx, make sure you're on the latest release by using the `@latest` tag: `npx -y jellyfish-mcp-server@latest`.
-- In Cursor, if the server fails to connect with an error like `ENOENT ... /Applications/Cursor.app/.../resources/lib`, Cursor is falling back to its own bundled Node instead of yours (it doesn't inherit your terminal's `PATH`). This is common with a Node version manager (mise/nvm/asdf). Fix it by pointing `command` directly at your `node` binary and passing `npx` as the first arg — see step 4 of the [Cursor](#cursor) setup.
+- In Cursor, if the server fails to connect with an error like `ENOENT ... /Applications/Cursor.app/.../resources/lib`, Cursor is falling back to its own bundled Node instead of yours (it doesn't inherit your terminal's `PATH`). This is common with a Node version manager (mise/nvm/asdf). Fix it by pointing `command` directly at your `node` binary and passing `npx` as the first arg — see above in the [Cursor](#cursor) setup.
 - For Docker, confirm Docker is running: `docker info`.
 - If PromptGuard is unexpectedly blocking responses, set `MODEL_AVAILABILITY=true` to allow data through when PromptGuard can't be reached, or unset `HUGGINGFACE_API_TOKEN` to disable PromptGuard entirely.


### PR DESCRIPTION
## Summary

- Adds a note explaining that Cursor runs in an isolated bash environment that does not inherit the terminal's `PATH`, so `npx` cannot be resolved by name alone
- Adds a **Before configuration** section instructing users to verify `npx` is installed and find its full path before configuring the MCP server
- Changes the `command` value in the Cursor npx example from `"npx"` to `"path/to/npx"` to reflect that the absolute path is required

## Test plan

- [ ] Verify the Cursor npx JSON snippet renders correctly in the docs
- [ ] Confirm the note and pre-configuration steps are clear and actionable for a new user

🤖 Generated with [Claude Code](https://claude.com/claude-code)